### PR TITLE
Fix string-replace parse warning when generating tests

### DIFF
--- a/spec/javascripts/unit/core/channels/channel_spec.js
+++ b/spec/javascripts/unit/core/channels/channel_spec.js
@@ -228,7 +228,7 @@ describe("Channel", function() {
 
       expect(pusher.send_event).toHaveBeenCalledWith(
         "pusher:subscribe",
-        { auth: "one", channel_data: "two", channel: "test" },
+        { auth: "one", channel_data: "two", channel: "test" }
       );
     });
 


### PR DESCRIPTION
The following warning is printed for the webpack config to generate the channel_spec tests.

```
WARNING in ./spec/javascripts/unit/core/channels/channel_spec.js
Module parse failed: /workspace/node_modules/string-replace-webpack-plugin/loader.js?id=3fpdwa2haeu!/workspace/node_modules/es3ify-loader/index.js!/workspace/spec/javascripts/unit/core/channels/channel_spec.js Unexpected token (232:6)
You may need an appropriate loader to handle this file type.
```

Removing the trailing comma fixes the warning.