### PR TITLE
Add url config option

### DIFF
--- a/spec/javascripts/unit/isomorphic/transports/transports_spec.js
+++ b/spec/javascripts/unit/isomorphic/transports/transports_spec.js
@@ -50,6 +50,15 @@ describe("Transports", function() {
       );
     });
 
+    it("should generate correct URLs with custom URL config", function() {
+      var url = Transports.ws.hooks.urls.getInitial("foobar", {
+        url: "wss://live.example.org:999/custom/path"
+      });
+      expect(url).toEqual(
+        "wss://live.example.org:999/custom/path"
+      );
+    });
+
     it("should not have a resource file", function() {
       expect(Transports.ws.hooks.file).toBe(undefined);
     });

--- a/src/core/transports/url_scheme.ts
+++ b/src/core/transports/url_scheme.ts
@@ -3,6 +3,7 @@ export interface URLSchemeParams {
   hostTLS: string;
   hostNonTLS: string;
   httpPath: string;
+  url: string;
 }
 
 interface URLScheme {

--- a/src/core/transports/url_schemes.ts
+++ b/src/core/transports/url_schemes.ts
@@ -19,6 +19,10 @@ function getGenericPath(key : string, queryString?:string) : string {
 
 export var ws : URLScheme = {
     getInitial: function(key : string , params : URLSchemeParams) : string {
+        if (params.url) {
+          return params.url;
+        }
+
         var path = (params.httpPath || "") + getGenericPath(key, "flash=false");
         return getGenericURL("ws", params, path);
     }


### PR DESCRIPTION
## What does this PR do?

Adds a `url` config option bypassing URL construction, allowing use of a pusher compatible API hosted at a specific URL.

## Checklist

- [x] All new functionality has tests.
- [x] All tests are passing.
- [ ] New or changed API methods have been documented.
